### PR TITLE
Fix file input disable logic

### DIFF
--- a/apps/web/src/pages/gallery/browser.ts
+++ b/apps/web/src/pages/gallery/browser.ts
@@ -23,7 +23,7 @@ if (masonry && inputField) {
       }
 
       if (form && validFiles.length) {
-        form.disabled = true;
+        inputField.disabled = true;
         form.classList.add("loading");
         const formData = new FormData(form);
         try {
@@ -46,8 +46,10 @@ if (masonry && inputField) {
           }
         } catch (e) {
           console.error(e);
+        } finally {
+          form.classList.remove("loading");
+          inputField.disabled = false;
         }
-        form.classList.remove("loading");
       }
     }
   });


### PR DESCRIPTION
## Summary
- disable file input during gallery upload
- re-enable file input when upload completes

## Testing
- `npm test` *(fails: Husky not found)*
- `npm run lint` *(fails: Cannot find package 'eslint-config-prettier')*