### PR TITLE
Add backend tests for error handling and OpenAPI

### DIFF
--- a/apps/backend/test/handlers/error.handler.test.ts
+++ b/apps/backend/test/handlers/error.handler.test.ts
@@ -1,0 +1,54 @@
+import { Hono } from 'hono';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { handleError } from '../../src/handlers/error.handler';
+import { ValidationError } from '../../src/classes/ValidationError.class';
+import { z } from '@hono/zod-openapi';
+
+const createApp = () => {
+  const app = new Hono();
+  app.onError((err, c) => handleError(err, c));
+  return app;
+};
+
+describe('handleError', () => {
+  let app: ReturnType<typeof createApp>;
+  beforeEach(() => {
+    app = createApp();
+  });
+
+  it('handles BaseError instances', async () => {
+    app.get('/base', () => {
+      throw new ValidationError('Invalid', [
+        { field: 'name', code: 'REQUIRED', message: 'name required' },
+      ]);
+    });
+    const res = await app.request('/base');
+    const data = await res.json();
+    expect(res.status).toBe(400);
+    expect(data.code).toBe('VALIDATION_ERROR');
+    expect(data.requestId).toBeDefined();
+  });
+
+  it('converts ZodError to ValidationError', async () => {
+    const schema = z.object({ name: z.string() });
+    app.get('/zod', () => {
+      schema.parse({});
+      return new Response();
+    });
+    const res = await app.request('/zod');
+    const data = await res.json();
+    expect(res.status).toBe(400);
+    expect(data.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('wraps unknown errors in SystemError', async () => {
+    app.get('/unknown', () => {
+      throw new Error('boom');
+    });
+    const res = await app.request('/unknown');
+    const data = await res.json();
+    expect(res.status).toBe(500);
+    expect(data.code).toBe('UNEXPECTED_ERROR');
+    expect(data.requestId).toBeDefined();
+  });
+});

--- a/apps/backend/test/openapi.config.test.ts
+++ b/apps/backend/test/openapi.config.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { createOpenAPIApp } from '../src/config/openapi.config';
+
+const app = createOpenAPIApp();
+
+describe('OpenAPI endpoints', () => {
+  it('serves the OpenAPI specification', async () => {
+    const res = await app.request('/specification.json');
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.openapi).toBe('3.1.1');
+  });
+
+  it('serves the Swagger UI page', async () => {
+    const res = await app.request('/docs');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+  });
+});

--- a/apps/backend/test/utils/response-builder.util.test.ts
+++ b/apps/backend/test/utils/response-builder.util.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { buildStandardResponses } from '../../src/utils/response-builder.util';
+import { z } from '@hono/zod-openapi';
+
+describe('buildStandardResponses', () => {
+  const schema = z.object({ ok: z.boolean() });
+
+  it('generates responses for a list route', () => {
+    const responses = buildStandardResponses({
+      method: 'get',
+      path: '/items',
+      resourceName: 'Item',
+      responseSchema: schema,
+      requiresAuth: false,
+    });
+    expect(responses['200']).toBeDefined();
+    expect(responses['404']).toBeUndefined();
+    expect(responses['401']).toBeUndefined();
+  });
+
+  it('includes auth errors when authentication is required', () => {
+    const responses = buildStandardResponses({
+      method: 'post',
+      path: '/items',
+      resourceName: 'Item',
+      responseSchema: schema,
+      requiresAuth: true,
+    });
+    expect(responses['201']).toBeDefined();
+    expect(responses['401']).toBeDefined();
+    expect(responses['403']).toBeDefined();
+  });
+
+  it('includes 404 for routes with path variables', () => {
+    const responses = buildStandardResponses({
+      method: 'get',
+      path: '/items/{id}',
+      resourceName: 'Item',
+      responseSchema: schema,
+      requiresAuth: false,
+    });
+    expect(responses['200']).toBeDefined();
+    expect(responses['404']).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add error handler unit tests
- cover response builder utilities
- test OpenAPI config endpoints

## Testing
- `npm run test -w apps/backend`

------
https://chatgpt.com/codex/tasks/task_b_6842e67f84808324a147883b03115ee9