### PR TITLE
Implement dynamic route loader

### DIFF
--- a/apps/backend/src/routes/index.ts
+++ b/apps/backend/src/routes/index.ts
@@ -1,3 +1,3 @@
-import storageRoutes from './v1/storage';
+import loadRoutes from './loader';
 
-export default [...storageRoutes];
+export default loadRoutes();

--- a/apps/backend/src/routes/loader.ts
+++ b/apps/backend/src/routes/loader.ts
@@ -1,0 +1,25 @@
+export type RouteRegister = (app: any) => void;
+
+/**
+ * Dynamically loads all route modules within this directory.
+ * Any exported function from `*.route.ts` files is treated as a route
+ * registration function.
+ */
+export function loadRoutes() {
+  const modules = import.meta.glob('./**/*.route.ts', { eager: true });
+  const routes: RouteRegister[] = [];
+  Object.values(modules).forEach((mod: any) => {
+    for (const value of Object.values(mod)) {
+      if (typeof value === 'function') {
+        routes.push(value);
+      } else if (Array.isArray(value)) {
+        value.forEach((v) => {
+          if (typeof v === 'function') routes.push(v);
+        });
+      }
+    }
+  });
+  return routes;
+}
+
+export default loadRoutes;

--- a/apps/backend/test/index.test.ts
+++ b/apps/backend/test/index.test.ts
@@ -1,6 +1,7 @@
 import { env } from 'cloudflare:test';
 import { describe, it, expect } from 'vitest';
 import { app } from '../src/index';
+import routes from '../src/routes';
 
 describe('Example', () => {
   it('Should return 200 response', async () => {
@@ -10,5 +11,9 @@ describe('Example', () => {
       success: true,
       message: 'Welcome to Flarekit APIs!',
     });
+  });
+
+  it('Should automatically load routes', () => {
+    expect(routes.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- auto-load route modules using `import.meta.glob`
- adjust backend route index to use loader
- update tests to verify routes load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6842e678cccc83249eb9c076395c4edb