### PR TITLE
Fix soft delete validation in bulkDelete

### DIFF
--- a/packages/database/src/services/base.service.ts
+++ b/packages/database/src/services/base.service.ts
@@ -469,6 +469,13 @@ export class BaseService<
 
       return deletedRows as TSelect[];
     } else {
+      if (!('deletedAt' in columns)) {
+        throw new ServiceError(
+          400,
+          "Schema does not have a 'deletedAt' field, cannot perform soft delete.",
+        );
+      }
+
       const now = toSQLiteUTCString(new Date());
       const updatedRows = await this.ctx.db
         .update(this.schema)

--- a/packages/database/test/services/base.service.test.ts
+++ b/packages/database/test/services/base.service.test.ts
@@ -1,0 +1,31 @@
+import { createExecutionContext, env } from 'cloudflare:test';
+import { describe, it, expect } from 'vitest';
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { BaseService } from '@/services/base.service';
+import { initDBInstance, getInstance } from '@/index';
+import { ServiceError } from '@/classes/service_error.class';
+
+const ctx = createExecutionContext();
+initDBInstance(ctx, env);
+const instance = getInstance(ctx);
+if (!instance) {
+  throw new Error(
+    'Ctx instance not found. Make sure initDatabase is implemented',
+  );
+}
+
+const noSoftDeleteSchema = sqliteTable('no_soft_delete', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+});
+
+const testService = new BaseService<
+  typeof noSoftDeleteSchema.$inferInsert,
+  typeof noSoftDeleteSchema.$inferSelect
+>(noSoftDeleteSchema, instance as any);
+
+describe('base.service bulkDelete', () => {
+  it('should throw ServiceError when deletedAt column is missing', async () => {
+    await expect(testService.bulkDelete(['1'])).rejects.toThrow(ServiceError);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `bulkDelete` requires a `deletedAt` column for soft deletes
- add unit test validating the new `bulkDelete` behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684a72e34bc08324afc580fddfacdf62