### PR TITLE
Add BaseService multi-fetch methods

### DIFF
--- a/.cursor/rules/database-service-patterns.mdc
+++ b/.cursor/rules/database-service-patterns.mdc
@@ -43,6 +43,8 @@ export const services = (ctx: Ctx) => ({
   - `delete(id, permanent?)` - Soft or hard delete
   - `getById(id, includeDeleted?)` - Get single record
   - `getByShortId(shortId, includeDeleted?)` - Get by shortId if available
+  - `getMany(ids, includeDeleted?)` - Fetch multiple records by ID
+  - `getManyReference(referenceField, id, range?, sort?, filter?, includeDeleted?)` - Fetch records by foreign key
   - `getList(range?, sort?, filter?, includeDeleted?)` - Paginated list
   - `getCount(filter?, includeDeleted?)` - Count records
   - `bulkUpdate(updates)` - Bulk update operations

--- a/packages/database/test/services/storage.service.test.ts
+++ b/packages/database/test/services/storage.service.test.ts
@@ -199,6 +199,57 @@ describe('storage.service', () => {
     });
   });
 
+  describe('Get many records', () => {
+    it('should fetch multiple records by id', async () => {
+      const r1 = await db.storage.create({
+        key: 'many-1',
+        originalName: 'f1',
+        size: 1,
+        mimeType: 'text/plain',
+        hash: 'h1',
+      });
+      const r2 = await db.storage.create({
+        key: 'many-2',
+        originalName: 'f2',
+        size: 2,
+        mimeType: 'text/plain',
+        hash: 'h1',
+      });
+
+      const records = await db.storage.getMany([r1.id, r2.id]);
+      expect(records.map((r) => r.id).sort()).toEqual([r1.id, r2.id].sort());
+    });
+
+    it('should filter by reference field', async () => {
+      const h = 'refhash';
+      const a = await db.storage.create({
+        key: 'ref-1',
+        originalName: 'f1',
+        size: 1,
+        mimeType: 'text/plain',
+        hash: h,
+      });
+      await db.storage.create({
+        key: 'ref-2',
+        originalName: 'f2',
+        size: 2,
+        mimeType: 'text/plain',
+        hash: h,
+      });
+      await db.storage.create({
+        key: 'ref-3',
+        originalName: 'f3',
+        size: 3,
+        mimeType: 'text/plain',
+        hash: 'other',
+      });
+
+      const refRecords = await db.storage.getManyReference('hash', h);
+      expect(refRecords.length).toBe(2);
+      expect(refRecords.some((r) => r.id === a.id)).toBe(true);
+    });
+  });
+
   describe('Get Storage List', () => {
     it('Should list all active (non-deleted) records in descending order of createdAt', async () => {
       const input = {


### PR DESCRIPTION
## Summary
- implement `getMany` and `getManyReference` in BaseService
- document new service APIs
- add tests for new database service methods

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684a72eab9a883248fcc53cbe39611b5