### PR TITLE
Fix storage list header

### DIFF
--- a/apps/backend/src/routes/v1/storage/storageList.route.ts
+++ b/apps/backend/src/routes/v1/storage/storageList.route.ts
@@ -119,7 +119,7 @@ export const storageListEndpoint = createApiEndpoint({
         });
 
       return c.json(storageList, 200, {
-        'Content-Range': `content ${parsedRange[0]}-${parsedRange[1]}/${totalItems}`,
+        'Content-Range': `storage ${parsedRange[0]}-${parsedRange[1]}/${totalItems}`,
         'Access-Control-Expose-Headers': 'Content-Range',
       });
     } catch (error) {

--- a/apps/backend/test/routes/storageList.route.test.ts
+++ b/apps/backend/test/routes/storageList.route.test.ts
@@ -1,0 +1,26 @@
+import { env, createExecutionContext } from 'cloudflare:test';
+import { describe, it, expect } from 'vitest';
+import { app } from '@/index';
+import { initDBInstance } from '@flarekit/database';
+
+/** Ensure the storage list route returns Content-Range header using storage prefix */
+
+describe('Storage List Route', () => {
+  it('returns Content-Range header with storage prefix', async () => {
+    const ctx = createExecutionContext();
+    const db = initDBInstance(ctx, env);
+
+    await db.storage.create({
+      key: 'test-key',
+      originalName: 'file.txt',
+      size: 10,
+      mimeType: 'text/plain',
+      hash: 'abc',
+    });
+
+    const res = await app.request('/api/v1/storage?range=[0,0]', {}, env);
+    expect(res.status).toBe(200);
+    const header = res.headers.get('Content-Range');
+    expect(header).toBe(`storage 0-0/1`);
+  });
+});


### PR DESCRIPTION
## Summary
- update Content-Range header to use `storage`
- test storage list response headers

## Testing
- `npm run test -w @flarekit/backend`

------
https://chatgpt.com/codex/tasks/task_b_684a73c29bb483248d6dc4428e94d61e