### PR TITLE
Return 201 on storage upload success

### DIFF
--- a/apps/backend/src/routes/v1/storage/storageCreate.route.ts
+++ b/apps/backend/src/routes/v1/storage/storageCreate.route.ts
@@ -69,11 +69,14 @@ export const storageCreateEndpoint = createApiEndpoint({
 
     try {
       const uploadData = await uploadFiles(allUploadedImages, c.env);
-      return c.json({
-        success: true,
-        message: 'Images uploaded successfully',
-        data: uploadData,
-      });
+      return c.json(
+        {
+          success: true,
+          message: 'Images uploaded successfully',
+          data: uploadData,
+        },
+        201,
+      );
     } catch (ex) {
       if (ex instanceof Error) {
         throw ExternalServiceError.serviceUnavailable('File storage service', {

--- a/apps/backend/test/routes/upload.route.test.ts
+++ b/apps/backend/test/routes/upload.route.test.ts
@@ -44,7 +44,7 @@ describe('Upload Route', () => {
 
     const responseData: any = (await response.json()) as any;
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(201);
     expect(responseData.message).toBe('Images uploaded successfully');
     expect(responseData.data).toHaveLength(1);
     expect(responseData.data?.[0]?.originalName).toBe(file.name);
@@ -78,7 +78,7 @@ describe('Upload Route', () => {
 
     const responseData: any = (await response.json()) as any;
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(201);
     expect(responseData.message).toBe('Images uploaded successfully');
     expect(responseData.data).toHaveLength(1);
     expect(responseData.data?.[0]?.originalName).toBe(atyantikFile.name);
@@ -150,7 +150,7 @@ describe('Upload Route', () => {
     );
 
     const responseData: any = (await response.json()) as any;
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(201);
     expect(responseData.message).toBe('Images uploaded successfully');
     expect(responseData.data).toHaveLength(1);
     expect(responseData.data?.[0]?.append).toBe(true);
@@ -165,7 +165,7 @@ describe('Upload Route', () => {
     );
 
     const reuploadResponseData: any = (await reuploadResponse.json()) as any;
-    expect(reuploadResponse.status).toBe(200);
+    expect(reuploadResponse.status).toBe(201);
     expect(reuploadResponseData.message).toBe('Images uploaded successfully');
     expect(reuploadResponseData.data).toHaveLength(1);
     expect(reuploadResponseData.data?.[0]?.append).toBe(false);


### PR DESCRIPTION
## Summary
- storage create route now returns status 201 after successful uploads
- update tests to expect 201

## Testing
- `npm run test -w @flarekit/backend`

------
https://chatgpt.com/codex/tasks/task_b_684a73b47e70832481d58083cd9028b3