### PR TITLE
Add logger util and use across backend handlers

### DIFF
--- a/apps/backend/src/handlers/error.handler.ts
+++ b/apps/backend/src/handlers/error.handler.ts
@@ -5,6 +5,7 @@ import { AppContext } from '@/types';
 import { Context } from 'hono';
 import { ContentfulStatusCode } from 'hono/utils/http-status';
 import { ZodError } from 'zod';
+import { logError, logWarn } from '@utils/logger.util';
 
 /**
  * Generates a unique request ID for error tracking
@@ -16,7 +17,7 @@ const generateRequestId = (): string => {
 /**
  * Logs error with structured format for monitoring and debugging
  */
-const logError = (
+const logStructuredError = (
   error: BaseError,
   requestId: string,
   c: Context<AppContext>,
@@ -43,10 +44,10 @@ const logError = (
   };
 
   if (options.severe || error.status >= 500) {
-    console.error('[SEVERE ERROR]', JSON.stringify(logData, null, 2));
+    logError('[SEVERE ERROR]', JSON.stringify(logData, null, 2));
     // Here you could integrate with external error tracking (Sentry, etc.)
   } else {
-    console.warn('[APPLICATION ERROR]', JSON.stringify(logData, null, 2));
+    logWarn('[APPLICATION ERROR]', JSON.stringify(logData, null, 2));
   }
 };
 
@@ -64,7 +65,7 @@ export const handleError = (ex: unknown, c: Context<AppContext>) => {
       (ex as any).requestId = requestId;
     }
 
-    logError(ex, requestId, c);
+    logStructuredError(ex, requestId, c);
     return c.json(ex.toJSON(), ex.status as ContentfulStatusCode);
   }
 
@@ -91,7 +92,7 @@ export const handleError = (ex: unknown, c: Context<AppContext>) => {
     (validationError as any).requestId = requestId;
     validationError.context.zodIssues = zodError.issues;
 
-    logError(validationError, requestId, c);
+    logStructuredError(validationError, requestId, c);
     return c.json(
       validationError.toJSON(),
       validationError.status as ContentfulStatusCode,
@@ -118,7 +119,7 @@ export const handleError = (ex: unknown, c: Context<AppContext>) => {
     },
   });
 
-  logError(systemError, requestId, c, { severe: true });
+  logStructuredError(systemError, requestId, c, { severe: true });
 
   // Return safe error response (without sensitive internal details in production)
   const response = systemError.toJSON();

--- a/apps/backend/src/handlers/queue.handler.ts
+++ b/apps/backend/src/handlers/queue.handler.ts
@@ -8,8 +8,10 @@
  * @returns {Promise<void>} Resolves when all messages have been acknowledged.
  */
 
+import { logInfo } from '@utils/logger.util';
+
 export const queueHandler: ExportedHandlerQueueHandler<Env> = async (batch) => {
-  let messages = JSON.stringify(batch.messages);
-  console.log(`Consumed from our queue: ${messages}`);
+  const messages = JSON.stringify(batch.messages);
+  logInfo(`Consumed from our queue: ${messages}`);
   batch.ackAll();
 };

--- a/apps/backend/src/utils/logger.util.ts
+++ b/apps/backend/src/utils/logger.util.ts
@@ -1,0 +1,11 @@
+export const logInfo = (...args: unknown[]) => {
+  console.log(...args);
+};
+
+export const logWarn = (...args: unknown[]) => {
+  console.warn(...args);
+};
+
+export const logError = (...args: unknown[]) => {
+  console.error(...args);
+};


### PR DESCRIPTION
## Summary
- add `logger.util.ts` for info/warn/error wrappers
- use logger instead of direct console calls in queue and error handlers
- rename logger functions for clarity
- simplify import in error handler and rename helper to avoid naming clash

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6842e55c8f44832484dfa6c1f6280d21